### PR TITLE
made name optional in schema

### DIFF
--- a/prisma/migrations/20250107081447_made_name_optional_in_land_parcel_model/migration.sql
+++ b/prisma/migrations/20250107081447_made_name_optional_in_land_parcel_model/migration.sql
@@ -1,0 +1,4 @@
+-- AlterTable
+ALTER TABLE "LandParcel" ALTER COLUMN "name" DROP NOT NULL,
+ALTER COLUMN "location" DROP NOT NULL,
+ALTER COLUMN "location" SET DATA TYPE TEXT;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -16,7 +16,7 @@ datasource db {
 
 model LandParcel {
   id          Int      @id @default(autoincrement())
-  name        String
+  name        String?
   description String?
   ownerName   String?
   area        Float


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Database Changes**
	- Made the `name` field optional for Land Parcels
	- Updated `location` column to allow null values and changed its data type
	- Increased flexibility in data entry for Land Parcel records

<!-- end of auto-generated comment: release notes by coderabbit.ai -->